### PR TITLE
registration client has been renamed to "scc" (bnc#870869)

### DIFF
--- a/package/yast2-online-update-configuration.changes
+++ b/package/yast2-online-update-configuration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr 16 13:29:46 UTC 2014 - lslezak@suse.cz
+
+- registration client has been renamed to "scc" (bnc#870869)
+- zypp_config.rb: fixed a typo in the constant name
+- 3.1.5
+
+-------------------------------------------------------------------
 Wed Mar 26 14:56:00 UTC 2014 - robin.roth@kit.edu
 
 - Rerun zypper if it returns 103 which indicates that an update to 

--- a/package/yast2-online-update-configuration.spec
+++ b/package/yast2-online-update-configuration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-online-update-configuration
-Version:        3.1.4
+Version:        3.1.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/online_update_configuration.rb
+++ b/src/clients/online_update_configuration.rb
@@ -249,8 +249,8 @@ module Yast
         end
 
         if @ret == :register
-          if WFM.ClientExists("inst_suse_register")
-            WFM.call("inst_suse_register")
+          if WFM.ClientExists("scc")
+            WFM.call("scc")
           else
             Popup.Error(
               _("The registration module is not available.") + "\n" +

--- a/src/lib/online-update-configuration/zypp_config.rb
+++ b/src/lib/online-update-configuration/zypp_config.rb
@@ -27,10 +27,10 @@ class ZyppConfig
 
   def set_delta_rpm_config_value new_value
     return if new_value == use_deltarpm?
-    Yast::SCR.Write(CONFIG_USE_DELTA_RPM, new_value)
+    Yast::SCR.Write(CONFIG_USE_DELTARPM, new_value)
   end
 
   def get_delta_rpm_config_value
-    Yast::SCR.Read(CONFIG_USE_DELTA_RPM)
+    Yast::SCR.Read(CONFIG_USE_DELTARPM)
   end
 end


### PR DESCRIPTION
- zypp_config.rb: fixed a typo in the constant name
- 3.1.5
