### PR TITLE
Install the patches for all selected categories (bsc#1044018)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
     # disable rvm, use system Ruby
     - rvm reset
     - wget https://raw.githubusercontent.com/yast/yast-devtools/master/travis-tools/travis_setup.sh
-    - sh ./travis_setup.sh -p "rake yast2-devtools yast2-testsuite yast2 yast2-packager" -g "rspec:3.3.0 yast-rake gettext"
+    - sh ./travis_setup.sh -p "rake yast2-devtools yast2-testsuite yast2 yast2-packager gettext" -g "rspec:3.3.0 yast-rake gettext"
 script:
     - rake check:syntax
     - rake check:pot

--- a/package/yast2-online-update-configuration.changes
+++ b/package/yast2-online-update-configuration.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Jun 30 11:30:17 UTC 2017 - lslezak@suse.cz
+
+- Install the patches for all selected categories (not just the
+  first one) (bsc#1044018)
+- Properly handle the exist status for multiple categories
+- 3.1.6
+
+-------------------------------------------------------------------
 Wed Apr 16 13:29:46 UTC 2014 - lslezak@suse.cz
 
 - registration client has been renamed to "scc" (bnc#870869)

--- a/package/yast2-online-update-configuration.spec
+++ b/package/yast2-online-update-configuration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-online-update-configuration
-Version:        3.1.5
+Version:        3.1.6
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/bin/online_update
+++ b/src/bin/online_update
@@ -59,7 +59,7 @@ function runzypper {
         "$@"
         status=$?
     fi
-    exit $status
+    return $status
 }
 
 # trim whitespaces
@@ -68,8 +68,12 @@ AOU_PATCH_CATEGORIES=`echo $AOU_PATCH_CATEGORIES`
 if [ -z "$AOU_PATCH_CATEGORIES" ] ; then
   runzypper $zcmd
 else
-  for cat in $AOU_PATCH_CATEGORIES ; do
-    runzypper $zcmd --category "$cat"
-  done
-fi
+  # handle errors for multiple categories
+  ret=0
 
+  for cat in $AOU_PATCH_CATEGORIES ; do
+    runzypper $zcmd --category "$cat" || ret=$?
+  done
+
+  exit $ret
+fi


### PR DESCRIPTION
- Install the patches for all selected categories, not just the first one - the `exit` finished the script too early ([bsc#1044018](https://bugzilla.suse.com/show_bug.cgi?id=1044018))
- Properly handle the exist status for multiple categories (originally it returned the status of the last `zypper` invocation, potentially hiding any previous failures)
- 3.1.6