### PR TITLE
Prompt for root password.

### DIFF
--- a/src/desktop/online_update_configuration.desktop
+++ b/src/desktop/online_update_configuration.desktop
@@ -12,7 +12,7 @@ X-SuSE-YaST-AutoInstSchema=online_update_configuration.rnc
 X-SuSE-YaST-Keywords=online,update,YOU,patch
 
 Icon=yast-update-online-configuration
-Exec=/sbin/yast2 online_update_configuration
+Exec=xdg-su -c "/sbin/yast2 online_update_configuration"
 
 Name=Online Update Configuration
 GenericName=Online Update Configuration


### PR DESCRIPTION
When launched independently, eg from gnome-shell, this module fails because it runs as non-root.
See https://bugzilla.suse.com/show_bug.cgi?id=1132649