### PR TITLE
[SLE-15-SP2] Set X-SuSE-YaST-AutoInstClient

### DIFF
--- a/package/yast2-online-update-configuration.changes
+++ b/package/yast2-online-update-configuration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Aug 20 13:25:49 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- Set X-SuSE-YaST-AutoInstClient in desktop file (bsc#1175516).
+- 4.2.2
+
+-------------------------------------------------------------------
 Tue Aug 27 18:28:54 CEST 2019 - schubi@suse.de
 
 - Set X-SuSE-YaST-AutoInstResource in desktop file (bsc#144894).

--- a/package/yast2-online-update-configuration.spec
+++ b/package/yast2-online-update-configuration.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-online-update-configuration
-Version:        4.2.1
+Version:        4.2.2
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0

--- a/src/desktop/org.opensuse.yast.OnlineUpdateConfiguration.desktop
+++ b/src/desktop/org.opensuse.yast.OnlineUpdateConfiguration.desktop
@@ -10,6 +10,7 @@ X-SuSE-YaST-AutoInstClonable=true
 X-SuSE-YaST-AutoInstRequires=lan,proxy
 X-SuSE-YaST-AutoInstSchema=online_update_configuration.rnc
 X-SuSE-YaST-AutoInstResource=online_update_configuration
+X-SuSE-YaST-AutoInstClient=online_update_configuration_auto
 X-SuSE-YaST-Keywords=online,update,YOU,patch
 
 Icon=yast-update-online-configuration


### PR DESCRIPTION
## Problem

When trying to clone the configuration of the module, it fails because it is looking for a wrong client

> 2020-08-20 09:37:05 <3> wpyc055(13059) [Interpreter] modules/Call.rb:40 Can't find YCP client component **online-update-configuration_auto**: No such file or directory

This is because the module name it is being used to build the client name when it is not being explicitely given through the `X-SuSE-YaST-AutoInstClient` keyword in the desktop file. See https://github.com/yast/yast-autoinstallation/blob/7979b8a1267dbc7e5684da76460a48a0af12a941/src/clients/inst_autoconfigure.rb#L148-L156

 * https://bugzilla.suse.com/show_bug.cgi?id=1175516
 * https://trello.com/c/3ufjTBEv

## Solution

To specify the specific client name using the `X-SuSE-YaST-AutoInstClient` in the desktop file.

## Read more

https://yastgithubio.readthedocs.io/en/latest/autoyast-development/#desktop-configuration-file