### PR TITLE
bsc#1198848: simplify AutoYaST format

### DIFF
--- a/package/yast2-online-update-configuration.changes
+++ b/package/yast2-online-update-configuration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May 26 06:42:47 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Reduce nesting in the "category_filter" section of the AutoYaST
+  profile (bsc#1198848). The old (nested) format is still accepted.
+- 4.3.3
+
+-------------------------------------------------------------------
 Thu Aug 20 13:25:49 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - Set X-SuSE-YaST-AutoInstClient in desktop file (bsc#1175516).

--- a/package/yast2-online-update-configuration.spec
+++ b/package/yast2-online-update-configuration.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-online-update-configuration
-Version:        4.3.2
+Version:        4.3.3
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0

--- a/src/autoyast-rnc/online_update_configuration.rnc
+++ b/src/autoyast-rnc/online_update_configuration.rnc
@@ -26,4 +26,4 @@ include_recommends = element include_recommends { BOOLEAN }
 use_deltarpm = element use_deltarpm { BOOLEAN }
 update_interval  = element update_interval { STRING  }
 category_filter = element category_filter { LIST, category* }
-category = element category { STRING }
+category = element (category | listentry) { STRING }

--- a/src/autoyast-rnc/online_update_configuration.rnc
+++ b/src/autoyast-rnc/online_update_configuration.rnc
@@ -13,7 +13,7 @@ online_update_configuration =
       auto_agree_with_licenses? &
       include_recommends? &
       update_interval? &
-      category_filter? &
+      (category_filter | nested_category_filter)? &
       use_deltarpm?
     )
   }
@@ -25,5 +25,12 @@ auto_agree_with_licenses = element auto_agree_with_licenses { BOOLEAN }
 include_recommends = element include_recommends { BOOLEAN }
 use_deltarpm = element use_deltarpm { BOOLEAN }
 update_interval  = element update_interval { STRING  }
+
 category_filter = element category_filter { LIST, category* }
 category = element (category | listentry) { STRING }
+
+# Support for the old category_filter format (bsc#1198848)
+nested_category_filter = element category_filter {
+    MAP,
+    element category { LIST, category* }
+  }

--- a/src/modules/OnlineUpdateConfiguration.rb
+++ b/src/modules/OnlineUpdateConfiguration.rb
@@ -588,11 +588,8 @@ module Yast
         @includeRecommends
       )
       @use_deltarpm = settings.fetch('use_deltarpm', @use_deltarpm)
-      @currentCategories = Convert.convert(
-        Ops.get(settings, ["category_filter", "category"], @currentCategories),
-        :from => "any",
-        :to   => "list <string>"
-      )
+
+      @currentCategories = get_category_filter(settings["category_filter"])
 
       getInterval = Ops.get_string(settings, "update_interval", "")
 
@@ -603,7 +600,6 @@ module Yast
 
       true
     end
-
 
     # Write()
     def Write
@@ -665,7 +661,7 @@ module Yast
           @updateInterval,
           :name
         ),
-        "category_filter"                => { "category" => @currentCategories }
+        "category_filter"                => @currentCategories
       }
     end
 
@@ -694,6 +690,17 @@ module Yast
     publish :function => :Import, :type => "boolean (map)"
     publish :function => :Write, :type => "boolean ()"
     publish :function => :Export, :type => "map ()"
+
+  private
+
+    def get_category_filter(category_filter)
+      return category_filter if category_filter.is_a?(Array)
+
+      return category_filter.fetch("category", []) if category_filter.is_a?(Hash)
+
+      []
+    end
+
   end
 
   OnlineUpdateConfiguration = OnlineUpdateConfigurationClass.new

--- a/src/modules/OnlineUpdateConfiguration.rb
+++ b/src/modules/OnlineUpdateConfiguration.rb
@@ -694,11 +694,14 @@ module Yast
   private
 
     def get_category_filter(category_filter)
-      return category_filter if category_filter.is_a?(Array)
-
-      return category_filter.fetch("category", []) if category_filter.is_a?(Hash)
-
-      []
+      case category_filter
+      when Array
+        category_filter
+      when Hash
+        category_filter.fetch("category", [])
+      else
+        []
+      end
     end
 
   end

--- a/test/online_update_configuration_test.rb
+++ b/test/online_update_configuration_test.rb
@@ -29,24 +29,36 @@ describe Yast::OnlineUpdateConfiguration do
       "enable_automatic_online_update" => true,
       "skip_interactive_patches"       => false,
       "auto_agree_with_licenses"       => true,
-      "use_deltarpm"                   => true,
-      "include_recommends"             => false,
+      "use_deltarpm"                   => false,
+      "include_recommends"             => true,
       "update_interval"                => "daily",
-      "category_filter"                => { "category" => ["security"] }
+      "category_filter"                => ["security"]
     }
   end
 
   describe "#Import" do
-
     it "imports online update settings" do
       subject.Import(profile)
       expect(subject.enableAOU).to eq(true)
       expect(subject.skipInteractivePatches).to eq(false)
       expect(subject.autoAgreeWithLicenses).to eq(true)
-      expect(subject.use_deltarpm).to eq(true)
-      expect(subject.includeRecommends).to eq(false)
+      expect(subject.use_deltarpm).to eq(false)
+      expect(subject.includeRecommends).to eq(true)
       expect(subject.updateInterval).to eq(:daily)
       expect(subject.currentCategories).to eq(["security"])
+    end
+
+    context "when an empty profile is given" do
+      it "keeps the default values" do
+        subject.Import({})
+        expect(subject.enableAOU).to eq(false)
+        expect(subject.skipInteractivePatches).to eq(true)
+        expect(subject.autoAgreeWithLicenses).to eq(false)
+        expect(subject.use_deltarpm).to eq(true)
+        expect(subject.includeRecommends).to eq(false)
+        expect(subject.updateInterval).to eq(:weekly)
+        expect(subject.currentCategories).to eq([])
+      end
     end
   end
 
@@ -54,6 +66,15 @@ describe Yast::OnlineUpdateConfiguration do
     it "exports online update settings" do
       subject.Import(profile)
       expect(subject.Export).to eq(profile)
+    end
+
+    context "when it uses the old format for category_filter" do
+      it "sets the categories filter" do
+        subject.Import(
+          profile.merge("category_filter" => { "category" => ["security"]})
+        )
+        expect(subject.currentCategories).to eq(["security"])
+      end
     end
   end
 end

--- a/test/online_update_configuration_test.rb
+++ b/test/online_update_configuration_test.rb
@@ -1,0 +1,59 @@
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "test_helper"
+
+Yast.import "OnlineUpdateConfiguration"
+
+describe Yast::OnlineUpdateConfiguration do
+  before { subject.main }
+
+  let(:profile) do
+  {
+      "enable_automatic_online_update" => true,
+      "skip_interactive_patches"       => false,
+      "auto_agree_with_licenses"       => true,
+      "use_deltarpm"                   => true,
+      "include_recommends"             => false,
+      "update_interval"                => "daily",
+      "category_filter"                => { "category" => ["security"] }
+    }
+  end
+
+  describe "#Import" do
+
+    it "imports online update settings" do
+      subject.Import(profile)
+      expect(subject.enableAOU).to eq(true)
+      expect(subject.skipInteractivePatches).to eq(false)
+      expect(subject.autoAgreeWithLicenses).to eq(true)
+      expect(subject.use_deltarpm).to eq(true)
+      expect(subject.includeRecommends).to eq(false)
+      expect(subject.updateInterval).to eq(:daily)
+      expect(subject.currentCategories).to eq(["security"])
+    end
+  end
+
+  describe "#Export" do
+    it "exports online update settings" do
+      subject.Import(profile)
+      expect(subject.Export).to eq(profile)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Bug [bsc#1198848](https://bugzilla.suse.com/show_bug.cgi?id=1198848): *AutoYaST Online Update Configuration - `category_filter`*

The AutoYaST format used by this module looks like this one:

```xml
<online_update_configuration>
  <category_filter>
    <category t="list">
      <listentry>security</listentry>
    </category>
  </category_filter>
</online_update_configuration>
```

But according to the schema, it should look like this:

```xml
<online_update_configuration t="map">
  <auto_agree_with_licenses t="boolean">true</auto_agree_with_licenses>
  <category_filter t="list">
    <listentry>recommended</listentry>
    <listentry>yast</listentry>
  </category_filter>
</online_update_configuration>
```

We need to make them match.

## Solution

The second format looks much better, but the first one is the working one. So we have decided to:

* Support both formats when validating and importing.
* Export using the format already described by the schema.

## Testing

- Added a new unit test
- Tested manually
