### PR TITLE
Add requirement on aaa_base

### DIFF
--- a/package/yast2-online-update-configuration.changes
+++ b/package/yast2-online-update-configuration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Sat Nov  2 04:40:27 UTC 2024 - Danny Sauer <danny@dannysauer.com>
+
+- 5.0.1 add explicit dependency on aaa_base for profile.sh
+  https://github.com/yast/yast-online-update-configuration/issues/36
+
+-------------------------------------------------------------------
 Wed Aug 30 20:16:10 UTC 2023 - Josef Reidinger <jreidinger@suse.cz>
 
 - 5.0.0 (bsc#1185510)

--- a/package/yast2-online-update-configuration.spec
+++ b/package/yast2-online-update-configuration.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-online-update-configuration
-Version:        5.0.0
+Version:        5.0.1
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0
@@ -35,6 +35,7 @@ BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 
 PreReq:         %fillup_prereq
 # Wizard::SetDesktopTitleAndIcon
+Requires:       aaa_base
 Requires:       yast2 >= 2.21.0
 Requires:       yast2-packager >= 2.17.0
 Requires:       yast2-pkg-bindings >= 2.17.20


### PR DESCRIPTION
## Problem

online_update script sources /etc/profile.d/profile.sh, which is missing in JeOS and maybe other very basic images.  This causes the script to fail and updates to not be installed.
 
- yast/yast-online-update-configuration#36

## Solution

Add explicit dependency for /etc/profile.d/profile.sh package Resolves yast/yast-online-update-configuration#36


## Testing

- Build in OBS fork.  Verify that missing aaa_base package gets pulled in when installed from fork.

## Screenshots

N/A, but test results showing aaa_base being installed as a dependency:
```
sauer@pecanpi:~> sudo rpm --erase aaa_base --nodeps
Removed '/etc/systemd/system/default.target.wants/soft-reboot-cleanup.service'.

sauer@pecanpi:~> sudo zypper install https://download.opensuse.org/repositories/home:/dannysauer:/branches:/openSUSE:/Factory/openSUSE_Tumbleweed/noarch/yast2-online-update-configuration-5.0.1-11.1.noarch.rpm
Loading repository data...
Reading installed packages...
Resolving package dependencies...

The following package is going to be upgraded:
  yast2-online-update-configuration

The following package is going to change vendor:
  yast2-online-update-configuration  openSUSE -> obs://build.opensuse.org/home:dannysauer:branches:openSUSE:Factory

The following NEW package is going to be installed:
  aaa_base

1 package to upgrade, 1 new, 1 to change vendor.

Package download size:   114.7 KiB

Package install size change:
              |     389.6 KiB  required by packages that will be installed
   307.4 KiB  |  -   82.2 KiB  released by packages that will be removed

Backend:  classic_rpmtrans
Continue? [y/n/v/...? shows all options] (y):
```