### PR TITLE
Check additional paths for profile.sh

### DIFF
--- a/package/yast2-online-update-configuration.changes
+++ b/package/yast2-online-update-configuration.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Sat Nov  2 06:18:51 UTC 2024 - Danny Sauer <danny@dannysauer.com>
+
+- 5.0.2 check extra paths profile.sh
+
+-------------------------------------------------------------------
 Wed Aug 30 20:16:10 UTC 2023 - Josef Reidinger <jreidinger@suse.cz>
 
 - 5.0.0 (bsc#1185510)

--- a/package/yast2-online-update-configuration.spec
+++ b/package/yast2-online-update-configuration.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-online-update-configuration
-Version:        5.0.0
+Version:        5.0.2
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0

--- a/src/bin/online_update
+++ b/src/bin/online_update
@@ -1,7 +1,14 @@
 #!/bin/bash
 
 # source the profile to get proper proxy settings, bnc#(678888)
-. /etc/profile.d/profile.sh
+for F in {/usr,}/etc/profile.d/profile.sh
+do
+    if [ -f "$F" ]
+    then
+        . "$F"
+        break
+    fi
+done
 
 zyppercmd="/usr/bin/zypper"
 zcmd="/bin/false"


### PR DESCRIPTION
## Problem

New aaa_base package puts profile.sh in /usr/etc/profile.d.  "New" means 2021. Whoops.

- #37 
- openSUSE/aaa_base#92


## Solution

In order, check /usr/etc/profile.d then /etc/profile.d.  This updates the script to check there, then the old location, then just carry on if neither is found.  I included a 5.0.2 changelog and spec bump since I did it after 5.0.1 in #37, but I guess it can be easily updated to whatever works. ;)


## Testing

Manual edit on local machine works, so package is probably also fine. :D


## Screenshots

N/A